### PR TITLE
feat: modularize shared-vm configs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,8 +16,6 @@ NIXDISK ?= nvme0n1
 # reused a lot so we just store them up here.
 SSH_OPTIONS=-o PubkeyAuthentication=no -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no
 
-
-
 vm/bootstrap0:
 	ssh $(SSH_OPTIONS) -p$(NIXPORT) root@$(NIXADDR) 'set -euxo pipefail; \
 	  DISK="/dev/$(NIXDISK)"; \
@@ -57,7 +55,6 @@ vm/bootstrap:
 		sudo reboot; \
 	"
 
-
 # copy our secrets into the VM
 vm/secrets:
 	# GPG keyring
@@ -70,7 +67,6 @@ vm/secrets:
 	rsync -av -e 'ssh $(SSH_OPTIONS)' \
 		--exclude='environment' \
 		$(HOME)/.ssh/ $(NIXUSER)@$(NIXADDR):~/.ssh
-
 
 # copy the Nix configurations into the VM.
 vm/copy:

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ In VMware Fusion, we'll create our boot system with the following configurations
 
 - Name the machine accordingly. I usually go with `NixOS`.
 - Set CPU cores to about half available, and memory to about half - 2/3s. Whatever feels comfortable, this can be tweaked.
-- Set hardrive to `nvme`, and give it at least 150 GB. Note, my particular M4 Max machine has nvme drives, but other machines might have different ones. Would need to modify the makefile accordingly for different SSD types because they would be identified differently for the partioning. 
+- Set hardrive to `nvme`, and give it at least 150 GB. Note, my particular M4 Max machine has nvme drives, but other machines might have different types of drives -- you should confirm this in your system report. You would need to modify the Makefile accordingly for different SSD types because they would be identified differently for the partioning. 
 - Enable graphics acceleration and use full retina display for diaplay settings.
 - Remove extra configs like the sounds card, video, etc. 
 

--- a/hosts/vm-aarch64/vm-aarch64-configuration.nix
+++ b/hosts/vm-aarch64/vm-aarch64-configuration.nix
@@ -1,4 +1,10 @@
-{ config, pkgs, lib, ... }: {
+{
+  config,
+  pkgs,
+  lib,
+  inputs,
+  ...
+}: {
   imports = [
     ./hardware-configuration.nix
     ./vm-shared.nix
@@ -13,6 +19,19 @@
   # Lots of stuff that uses aarch64 that claims doesn't work, but actually works.
   nixpkgs.config.allowUnfree = true;
   nixpkgs.config.allowUnsupportedSystem = true;
+
+  # Define your hostname.
+  networking.hostName = "vm-aarch64-nixos";
+
+  home-manager = {
+    extraSpecialArgs = {
+      inherit inputs;
+      flakeName = "vm-aarch64";
+    };
+    users = {
+      "leon" = import ../../users/leon/home.nix;
+    };
+  };
 
   # This works through our custom module imported above
   virtualisation.vmware.guest.enable = true;

--- a/hosts/vm-aarch64/vm-shared.nix
+++ b/hosts/vm-aarch64/vm-shared.nix
@@ -38,16 +38,6 @@
     ];
   };
 
-  home-manager = {
-    extraSpecialArgs = {
-      inherit inputs;
-      flakeName = "vm-aarch64";
-    };
-    users = {
-      "leon" = import ../../users/leon/home.nix;
-    };
-  };
-
   # Use the systemd-boot EFI boot loader.
   boot.loader.systemd-boot.enable = true;
   boot.loader.efi.canTouchEfiVariables = true;
@@ -55,9 +45,6 @@
   # VMware, Parallels both only support this being 0 otherwise you see
   # "error switching console mode" on boot.
   boot.loader.systemd-boot.consoleMode = "0";
-
-  # Define your hostname.
-  networking.hostName = "vm-aarch64-nixos";
 
   # Set your time zone.
   time.timeZone = "America/New_York";
@@ -90,7 +77,7 @@
   # Enable tailscale. We manually authenticate when we want with
   # "sudo tailscale up". If you don't use tailscale, you should comment
   # out or delete all of this.
-  #services.tailscale.enable = true;
+  services.tailscale.enable = true;
 
   # Define a user account. Don't forget to set a password with 'passwd'.
   users.mutableUsers = true;


### PR DESCRIPTION
Remove any specific mentions of `aarch64` from the `vm-shared` configuration.